### PR TITLE
Disable `performance_schema` monitoring by default

### DIFF
--- a/mysql/conf.d/custom.cnf
+++ b/mysql/conf.d/custom.cnf
@@ -20,11 +20,11 @@ log_bin_trust_function_creators=OFF
 log_bin=OFF
 bind-address=0.0.0.0
 
-# performance config
-performance_schema=ON
-performance-schema-instrument='statement/%=ON'
-performance-schema-consumer-statements-digest=ON
-innodb_monitor_enable=all
+# performance config - uncomment if you need "performance_schema" monitoring
+#performance_schema=ON
+#performance-schema-instrument='statement/%=ON'
+#performance-schema-consumer-statements-digest=ON
+#innodb_monitor_enable=all
 
 [mysql]
 


### PR DESCRIPTION
To not be slowing performance down by leaving it enabled.

<img width="744" alt="image" src="https://user-images.githubusercontent.com/1518618/199009281-86dae3be-9bcf-4b29-945f-4b59ae8fe835.png">

