### PR TITLE
Post Installation Cmd is executed within Docker Entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,9 @@
 
 cd /var/www/eramba || exit
 
+# Run Post Install CMD to generate app_local.php file with unique SALT and other defaults.
+su -s /bin/bash -c "php composer.phar run-script post-install-cmd --no-interaction" www-data
+
 # syncing dir structure into /data folder from /data_template
 su -s /bin/bash -c "rsync -rv app/upgrade/data_template/ app/upgrade/data/" www-data
 


### PR DESCRIPTION
Eramba in version 3.17.0 will not be running this Post Installation script during building of Docker Image. This Pull-Request changes will start to take effect when that release is out, which in the end means that Entrypoint will take over the `Post Install CMD` task and every Docker/SaaS deployment will have their own unique Security Salt.