### PR TITLE
Added `always` restart policy for containers and and some other tweaks

### DIFF
--- a/docker-compose.simple-install.yml
+++ b/docker-compose.simple-install.yml
@@ -4,6 +4,7 @@ services:
     container_name: mysql
     image: mysql:8.0.28-oracle
     command: ["mysqld", "--disable-log-bin"]
+    restart: always
     volumes:
       - db-data:/var/lib/mysql
       - ./mysql/conf.d:/etc/mysql/conf.d
@@ -16,9 +17,11 @@ services:
   redis:
     container_name: redis
     image: redis:6.0.16-alpine
+    restart: always
   eramba:
     container_name: eramba
     image: ghcr.io/eramba/eramba:latest
+    restart: always
     ports:
       - 8443:443
     volumes:
@@ -50,6 +53,7 @@ services:
     image: ghcr.io/eramba/eramba:latest
     command: ["cron", "-f"]
     entrypoint: ["/docker-cron-entrypoint.sh"]
+    restart: always
     volumes:
       - data:/var/www/eramba/app/upgrade/data
       - app:/var/www/eramba

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,7 +18,7 @@ su -s /bin/bash -c "php app/upgrade/bin/cake.php queue worker end all -q" www-da
 # Either load a clean database if eramba is deployed for the first time
 # or migrate and update to the latest database version if switching to a new/different image, if applicable,
 # otherwise if not possible to update due to broken DB history sync, the process will exit with error.
-su -s /bin/bash -c "php app/upgrade/bin/cake.php database initialize" www-data
+su -s /bin/bash -c "php app/upgrade/bin/cake.php database initialize" www-data || exit
 
 # Lets de-activate maintenance mode
 #su -s /bin/bash -c "php app/upgrade/bin/cake.php setup.maintenance_mode deactivate" www-data


### PR DESCRIPTION
1. all stopped containers will start itself when docker is started after reboot or whatever
2. also eramba container will stop automatically if entrypoint initial process fails (loading a clean database or migrating database or when there is no connection to mysql for some reason like wrong credentials, etc...)